### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ to make sure you are following the Hubii JavaScript coding style.
 
 ## Installation
 
-    npm install hubiinetwork/eslint-config --save-dev
+    npm install eslint hubiinetwork/eslint-config --save-dev
 
 ## Usage
 


### PR DESCRIPTION
If `eslint` isn't installed as a local dependency, npm falls back on the globally installed `eslint` (if it exists) that can't see the locally installed `@hubiinetwork/eslint-config`